### PR TITLE
Add shell.nix for easy setup with nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {}}:
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs.ocamlPackages; [
+    ocaml
+    findlib # Required to find the rest of the packages
+    dune_2
+  ];
+  buildInputs = with pkgs.ocamlPackages; [
+    alcotest
+    base
+  ];
+}


### PR DESCRIPTION
Having Nix you can now just `nix-shell` at the root folder and the dependencies are all setup at once for the current shell.